### PR TITLE
jsonplatform.c: fix potential segfault at pin label processing

### DIFF
--- a/docs/jsonplatform.md
+++ b/docs/jsonplatform.md
@@ -41,7 +41,7 @@ The number of json objects in layout should be equal to the pin_count.
 
 |Key        |Type   |Required   |Description                                    |
 |-----------|-------|-----------|-----------------------------------------------|
-|label      |string |yes        | The label used to describe the pin            |
+|label      |string |yes        | The label used to describe the pin (11 characters max) |
 |invalid    |boolean|no         | Sets the labeled pin as an invalid pin        |
 
 ### GPIO

--- a/src/json/jsonplatform.c
+++ b/src/json/jsonplatform.c
@@ -214,7 +214,8 @@ mraa_init_json_platform_io(json_object* jobj_io, mraa_board_t* board, int index)
         }
         temp_string = json_object_get_string(jobj_temp);
         // set the gpio label
-        strncpy(board->pins[pos].name, temp_string, 8);
+        memset(board->pins[pos].name, 0, MRAA_PIN_NAME_SIZE);
+        strncpy(board->pins[pos].name, temp_string, MRAA_PIN_NAME_SIZE - 1);
     } else {
         syslog(LOG_ERR, "init_json_platform: No IO Label");
         return MRAA_ERROR_INVALID_RESOURCE;


### PR DESCRIPTION
Also update docs to reflect the max label length.

Fixes #738.

Signed-off-by: Alex Tereschenko <alext.mkrs@gmail.com>